### PR TITLE
Fix typo Update transfer-tokens.md

### DIFF
--- a/docs/src/cli/transfer-tokens.md
+++ b/docs/src/cli/transfer-tokens.md
@@ -2,7 +2,7 @@
 title: Send and Receive Tokens
 ---
 
-This page decribes how to receive and send SOL tokens using the command line
+This page describes how to receive and send SOL tokens using the command line
 tools with a command line wallet such as a [paper wallet](../wallet-guide/paper-wallet.md),
 a [file system wallet](../wallet-guide/file-system-wallet.md), or a
 [hardware wallet](../wallet-guide/hardware-wallets.md). Before you begin, make sure


### PR DESCRIPTION
# Fix Typo in transfer-tokens.md

## Summary of Changes
- Corrected a typo: "decribes" to "describes" in the `docs/src/cli/transfer-tokens.md` file for improved accuracy.

---

## Additional Notes
This is a minor documentation update and does not affect the functionality of the project.  
Please review and merge at your convenience. Thank you! 😊
