### PR TITLE
fix typo overview.md

### DIFF
--- a/docs/src/developing/on-chain-programs/overview.md
+++ b/docs/src/developing/on-chain-programs/overview.md
@@ -112,7 +112,7 @@ less than the float equivalents:
 
 ```
          u64   f32
-Multipy    8   176
+Multiply    8   176
 Divide     9   219
 ```
 


### PR DESCRIPTION
Corrected "Multipy" to "Multiply" in the section where multiplication and division operations are discussed.